### PR TITLE
Update the compact-maintainers team membership

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -16,7 +16,11 @@ teams:
     maintainers:
       - kmillikin
     members:
-      - chrisferry
+      - bobblessinghartley
+      - dybvig
+      - JosephDenman
+      - leszek-shielded
+      - pataei
   - name: minokawa-maintainers
     maintainers:
       - kmillikin


### PR DESCRIPTION
Add all the `minokawa-maintainers` except `chrisferry`.  He's a `compact-admin`.