### PR TITLE
Add a `compact-triage` team

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -21,6 +21,11 @@ teams:
       - JosephDenman
       - leszek-shielded
       - pataei
+  - name: compact-triage
+    maintainers:
+      - kmillikin
+    members:
+      - andreyjv
   - name: minokawa-maintainers
     maintainers:
       - kmillikin
@@ -37,6 +42,7 @@ repositories:
       lf-staff: maintain
       compact-admins: admin
       compact-maintainers: maintain
+      compact-triage: triage
     visibility: public
   - name: governance
     teams:


### PR DESCRIPTION
The intent is that this team can triage issues and also maintain project boards.