### PR TITLE
Add an admin member to set up GitHub/Jira integration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,6 +12,7 @@ teams:
       - chrisferry
     members:
       - sgillespie
+      - lcarvalho-shielded
   - name: compact-maintainers
     maintainers:
       - kmillikin


### PR DESCRIPTION
The user https://github.com/lcarvalho-shielded is temporarily added as an admin to set up export of (internal) Shielded Jira tickets to GitHub.