### PR TITLE
Add security-managers group

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -39,6 +39,12 @@ teams:
       - JosephDenman
       - leszek-shielded
       - pataei
+  - name: security-managers
+    maintainers:
+      - bobblessinghartley
+    members:
+      - dybvig
+      - kmillikin
 repositories:
   - name: compact
     teams:
@@ -46,14 +52,17 @@ repositories:
       compact-admins: admin
       compact-maintainers: maintain
       compact-triage: triage
+      security-managers: read
     visibility: public
   - name: .github
     teams:
       lf-staff: maintain
       minokawa-maintainers: maintain
+      security-managers: read
     visibility: public
   - name: governance
     teams:
       lf-staff: maintain
       minokawa-maintainers: maintain
+      security-managers: read
     visibility: public


### PR DESCRIPTION
This group has read-only access to repos so they have visibility into private disclosures.