### PR TITLE
Remove sgillespie and skylarsimoncelli from the compact-admins

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,8 +12,6 @@ teams:
       - chrisferry
     members:
       - lcarvalho-shielded
-      - sgillespie
-      - skylarsimoncelli
   - name: compact-maintainers
     maintainers:
       - kmillikin


### PR DESCRIPTION
These two users do not need admin access at this time.